### PR TITLE
Adding detective module to browserify a script only when it requires other modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "browserify": "^16.5.0",
     "chalk": "^2.4.2",
     "commander": "^4.0.1",
+    "detective": "^5.2.0",
     "enquirer": "^2.3.2"
   },
   "devDependencies": {

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const browserify = require('browserify')
-const detective = require('detective');
+const detective = require('detective')
 const promisify = require('util').promisify
 const config = require('./lib/config')
 const file = require('./lib/file')


### PR DESCRIPTION
Related to #12.

Signed-off-by: Kevin Swiber <kswiber@gmail.com>