### PR TITLE
Exclude Postman Sandbox builtins and only bundle scripts when they have dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "browserify": "^16.5.0",
     "chalk": "^2.4.2",
     "commander": "^4.0.1",
+    "detective": "^5.2.0",
     "enquirer": "^2.3.2"
   },
   "devDependencies": {

--- a/src/sync.js
+++ b/src/sync.js
@@ -49,11 +49,8 @@ async function maybeBundle (path) {
 
 async function bundle (path) {
   const b = browserify()
+  b.external(sandboxBuiltins)
   b.add(path)
-
-  for (const builtin of sandboxBuiltins) {
-    b.external(builtin)
-  }
 
   const doBundle = promisify(b.bundle.bind(b))
   const buf = await doBundle()

--- a/src/sync.js
+++ b/src/sync.js
@@ -34,6 +34,19 @@ async function bundle (path) {
   const b = browserify()
   b.add(path)
 
+  // Reference: https://learning.postman.com/docs/writing-scripts/script-references/postman-sandbox-api-reference/
+  const sandboxBuiltins = [
+    'ajv', 'atob', 'btoa', 'chai', 'cheerio', 'crypto-js',
+    'csv-parse/lib/sync', 'lodash', 'moment', 'postman-collection',
+    'tv4', 'uuid', 'xml2js', 'path', 'assert', 'buffer', 'util',
+    'url', 'punycode', 'querystring', 'string-decoder', 'stream',
+    'timers', 'events'
+  ]
+
+  for (const builtin of sandboxBuiltins) {
+    b.external(builtin)
+  }
+
   const doBundle = promisify(b.bundle.bind(b))
   const buf = await doBundle()
   const script = buf.toString()


### PR DESCRIPTION
Fixes #36 
Related to #12

Signed-off-by: Kevin Swiber <kswiber@gmail.com>